### PR TITLE
fix: capitalize the `view` word

### DIFF
--- a/learning-guide/beginner.md
+++ b/learning-guide/beginner.md
@@ -14,7 +14,7 @@ Click the image to view on YouTube.
 | Title | Content | Length | 
 | --- | :-- | --- |
 | The Complete Guide to Full Stack Ethereum Development - Tutorial for Beginners [2021] | [![video](https://img.youtube.com/vi/a0osIaAOFSE/0.jpg)](https://www.youtube.com/watch?v=a0osIaAOFSE) | 1h 01m 04s
-| Local Solidity Development | [view](https://hardhat.org/) |
+| Local Solidity Development | [View](https://hardhat.org/) |
 
 ## Blog content 
 


### PR DESCRIPTION
Things added/changed:

- Capitalize the `view` word (seen in #10).
